### PR TITLE
Update the SDK Manager version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:18.04
 
+# ARGUMENTS
+ARG SDK_MANAGER_VERSION=0.9.14-4964
+ARG SDK_MANAGER_DEB=sdkmanager_${SDK_MANAGER_VERSION}_amd64.deb
+
 # add new sudo user
 ENV USERNAME jetpack
 ENV HOME /home/$USERNAME
@@ -63,10 +67,10 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 # install SDK Manager
 USER jetpack
-COPY sdkmanager_0.9.12-4180_amd64.deb /home/$USERNAME/
-WORKDIR /home/$USERNAME
-RUN sudo apt install ./sdkmanager_0.9.12-4180_amd64.deb
+COPY ${SDK_MANAGER_DEB} /home/${USERNAME}/
+WORKDIR /home/${USERNAME}
+RUN sudo apt-get install -f /home/${USERNAME}/${SDK_MANAGER_DEB}
 
 USER root
 RUN echo "${USERNAME}:${USERNAME}" | chpasswd
-RUN rm /home/$USERNAME/sdkmanager_0.9.12-4180_amd64.deb
+RUN rm /home/${USERNAME}/${SDK_MANAGER_DEB}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a Dockerfile to use [NVIDIA SDK Manager](https://docs.nvidia.com/sdk-man
 ### Download NVIDIA SDK Manager
 Please download the package of NVIDIA SDK Manager from <https://developer.nvidia.com/embedded/dlc/nv-sdk-manager>.  
 And, please put the package of NVIDIA SDK Manager in the same directory as the Dockerfile.  
-This time, I used `sdkmanager_0.9.12-4180_amd64.deb`.
+This time, I used `sdkmanager_0.9.14-4964_amd64.deb`.
 
 ### Build Docker image
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ This time, I used `sdkmanager_0.9.14-4964_amd64.deb`.
 $ docker build -t jetpack .
 ```
 
+To build a Docker image with a specific SDK Manager version override the ``SDK_MANAGER_VERSION`` variable in the Docker command line
+
+```
+$ docker build --build-arg SDK_MANAGER_VERSION=1.0.0-5517 -t jetpack .
+```
+
 ### Create Docker container
 ```
 $ ./launch_container.sh


### PR DESCRIPTION
The latest 0.9.14-4964 is used for installation. The definition
of the version was moved to a variable and one common variable for the .deb
file is used.

Signed-off-by: Christian Ege <christian.ege@ifm.com>