### PR TITLE
RFC: Persist SDK data between runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+jetpack_home
+sdkmanager_*

--- a/launch_container.sh
+++ b/launch_container.sh
@@ -5,10 +5,16 @@ XAUTH=/tmp/.docker.xauth
 touch $XAUTH
 xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
+mkdir -p jetpack_home/nvidia
+mkdir -p jetpack_home/Downloads
+JETPACK_HOME=$(realpath ./jetpack_home)
+
 docker run --privileged --rm -it \
            --volume=$XSOCK:$XSOCK:rw \
            --volume=$XAUTH:$XAUTH:rw \
            --volume=/dev:/dev:rw \
+           --volume=$JETPACK_HOME/nvidia:/home/jetpack/nvidia:rw \
+           --volume=$JETPACK_HOME/Downloads:/home/jetpack/Downloads:rw \
            --shm-size=1gb \
            --env="XAUTHORITY=${XAUTH}" \
            --env="DISPLAY=${DISPLAY}" \


### PR DESCRIPTION
Creates `jetson_home` directory on the host that keeps `Downloads` and `nvidia` directories after the container is closed.