### PR TITLE
fixed setup error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,16 +57,12 @@ RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selectio
 
 # install SDK Manager
 USER jetpack
-COPY ${SDK_MANAGER_DEB} /home/${USERNAME}/
+COPY --chown=jetpack:jetpack ${SDK_MANAGER_DEB} /home/${USERNAME}/
 WORKDIR /home/${USERNAME}
 RUN sudo apt-get install -f /home/${USERNAME}/${SDK_MANAGER_DEB}
-
-USER root
-RUN echo "${USERNAME}:${USERNAME}" | chpasswd
 RUN rm /home/${USERNAME}/${SDK_MANAGER_DEB}
 
-  # Configure qemu-user-static to avoid errors of the type:  ERROR : File System and OS : chroot: failed to run command 'mount': Exec format error.
-CMD sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
-CMD sudo update-binfmts --enable qemu-aarch64
-CMD sudo update-binfmts --enable qemu-arm
-CMD sudo update-binfmts --enable qemu-armeb
+# configure QEMU to fix https://forums.developer.nvidia.com/t/nvidia-sdk-manager-on-docker-container/76156/18
+COPY --chown=jetpack:jetpack configure_qemu.sh /home/${USERNAME}/
+CMD /home/${USERNAME}/configure_qemu.sh
+

--- a/configure_qemu.sh
+++ b/configure_qemu.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
+sudo update-binfmts --enable qemu-aarch64
+sudo update-binfmts --enable qemu-arm
+sudo update-binfmts --enable qemu-armeb


### PR DESCRIPTION
I failed to setup Jetson TX2 with `sdkmanager_1.5.0-7774_amd64.deb`.  
So, I fixed this problem.

![Screenshot from 2021-05-01 16-29-21](https://user-images.githubusercontent.com/2630323/116775051-8e5c5280-aa9b-11eb-816c-2733566c15a1.png)
