### PR TITLE
Dockerfile: Add new dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN yes | unminimize && \
         chromium-browser \
         qemu-user-static \
         binfmt-support \
+        libxshmfence1 \
         && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
SDK version 1.9.1 requres the installed libxshmfence1 package as a dependency.